### PR TITLE
fix(heroku): cope with lack of dependabot secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,22 +17,23 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: 11.0
-        distribution: 'adopt'
-    - name: Gradle Wrapper Cache
-      uses: actions/cache@v3
+        distribution: 'temurin'
+    - name: Bootstrap Variables
+      id: variables-bootstrap
+      run: |
+        echo "::set-output name=today::$(/bin/date -u "+%Y%m%d")"
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
       with:
-        path: ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
-    - name: Gradle Dependencies Cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-cache-${{ hashFiles('**/*.gradle') }}
+        gradle-version: wrapper
+        gradle-home-cache-excludes: dependency-check-data
     - name: Dependency Check Cache
       uses: actions/cache@v3
       with:
         path: ~/.gradle/dependency-check-data
-        key: ${{ runner.os }}-dependency-check-data-${{ hashFiles('**/build.gradle') }}
+        key: ${{ runner.os }}-dependency-check-data-${{ steps.variables-bootstrap.outputs.today }}
+        restore-keys: |
+          ${{ runner.os }}-dependency-check-data-
     - name: Gradle Check, Install & Sonar
       run: |
         ./gradlew -Dorg.gradle.console=plain --no-daemon -PverboseTests=true check sonarqube installDist

--- a/.github/workflows/depbot-publisher.yaml
+++ b/.github/workflows/depbot-publisher.yaml
@@ -1,13 +1,14 @@
-name: Publish
-
+name: dependabot-publisher
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["is-dependabot"]
+    types:
+      - completed
 
+# https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
 jobs:
-  main:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/reusable-publish.yml
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/is-depbot.yaml
+++ b/.github/workflows/is-depbot.yaml
@@ -1,0 +1,15 @@
+name: is-dependabot
+on:
+  push:
+    branches: master
+
+# Dependabot doesn't have access to secrets
+# when they instigate a standard PR github action.
+# https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
+# This then triggers dependabot-publish.yml
+jobs:
+  is-dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - run: echo "Activity by Dependabot"

--- a/.github/workflows/reusable-publish.yaml
+++ b/.github/workflows/reusable-publish.yaml
@@ -1,0 +1,113 @@
+name: reusable-publish
+
+on:
+  workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'Username for docker to publish image'
+        required: true
+      DOCKER_TOKEN:
+        description: 'Token for docker to publish image'
+        required: true
+      SONAR_TOKEN:
+        description: 'Token for sonarqube'
+        required: true
+      HEROKU_KEY:
+        description: 'Token for Heroku for deployment'
+        required: true
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up JDK 11.0
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11.0
+        distribution: 'temurin'
+    - name: Bootstrap Variables
+      id: variables-bootstrap
+      run: |
+        echo "::set-output name=today::$(/bin/date -u "+%Y%m%d")"
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: wrapper
+        gradle-home-cache-excludes: dependency-check-data
+    - name: Dependency Check Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.gradle/dependency-check-data
+        key: ${{ runner.os }}-dependency-check-data-${{ steps.variables-bootstrap.outputs.today }}
+        restore-keys: |
+          ${{ runner.os }}-dependency-check-data-
+    - name: Create GitHub deployment
+      id: deployment
+      uses: chrnorm/deployment-action@releases/v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        environment: interlok-hello-world
+    - name: Gradle Check, Install & Sonar
+      run: |
+        ./gradlew -Dorg.gradle.console=plain --no-daemon -PverboseTests=true check sonarqube installDist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Login to Heroku
+      uses: docker/login-action@v2
+      with:
+        registry: registry.heroku.com
+        username: "_"
+        password: ${{ secrets.HEROKU_KEY }}
+    - name: Docker Build and push
+      id: docker_build
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        platforms: linux/amd64
+        push: true
+        tags: |
+          adaptrislabs/interlok-hello-world:latest
+          registry.heroku.com/interlok-hello-world/web:latest
+    - name: Inspect
+      id: inspect
+      run: |
+        docker pull registry.heroku.com/interlok-hello-world/web:latest
+        echo "::set-output name=HEROKU_WEB_DOCKER_IMAGE_ID::$(docker inspect registry.heroku.com/interlok-hello-world/web:latest --format={{.Id}})"
+    - name: Update Heroku
+      uses: fjogeleit/http-request-action@master
+      with:
+        url: https://api.heroku.com/apps/interlok-hello-world/formation
+        method: PATCH
+        bearerToken: ${{ secrets.HEROKU_KEY }}
+        customHeaders: |
+          { "Accept": "application/vnd.heroku+json; version=3.docker-releases" }
+        data: |
+          { "updates": [ { "type": "web", "docker_image": "${{ steps.inspect.outputs.HEROKU_WEB_DOCKER_IMAGE_ID }}" } ] }
+    - name: Update deployment status (success)
+      if: success()
+      uses: chrnorm/deployment-status@releases/v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        environment_url: https://interlok-hello-world.herokuapp.com
+        state: success
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+    - name: Update deployment status (failure)
+      if: failure()
+      uses: chrnorm/deployment-status@releases/v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        environment_url: https://interlok-hello-world.herokuapp.com
+        state: failure
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
## Motivation

Dependabot generated PR's that are subsequently merged by asking dependabot to merge do not have access to secrets. 

At the moment the github sanctioned work-around is to either use `pull-request-target` or to use 2 workflows; a workflow fired by a workflow completion runs in the scope of the repository so will have access to secrets.

## Modification

- Add a is-dependabot action which completes successful if the actor is dependabot
- Add a depbot-publisher which does have access to secrets and is fired on completion of is-depbot
- publish itself refactored into reusable-publish.yaml and used by publish.yaml && depbot-publisher.yaml

## Result

Hopefully a publish and deployment in heroku

## Testing

Use ACT to check the action.
Because this [logging](https://github.com/adaptris-labs/interlok-hello-world/runs/6490379435?check_suite_focus=true#step:12:2)

```
Run docker/login-action@v2
  with:
    registry: registry.heroku.com
    username: _
    password: ***
    ecr: auto
    logout: true
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Adopt_jdk/11.0.11-9/x64
Logging into registry.heroku.com...
Error: Error response from daemon: login attempt to https://registry.heroku.com/v2/ failed with status: 401 Unauthorized
```

Currently I believe the Heroku key is incorrect because; the secret exists, but isn't recognised by heroku