### PR TITLE
Fix suexec-docker-entrypoint and make curl fail if 404

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache --update ca-certificates bash curl unzip su-exec && \
     adduser -S interlok -G interlok && \
     mkdir -p /opt/interlok && \
     chown interlok:interlok /opt/interlok && \
-    curl https://raw.githubusercontent.com/adaptris/docker-interlok-base/develop/scripts/suexec-docker-entrypoint.sh -o /docker-entrypoint.sh && \
+    curl -sf https://raw.githubusercontent.com/adaptris/docker-interlok-base/release/scripts/suexec-docker-entrypoint.sh -o /docker-entrypoint.sh && \
     chmod +x /docker-entrypoint.sh
 
 COPY --chown=interlok:interlok ./build/distribution /opt/interlok


### PR DESCRIPTION
## Motivation

```
2022-05-18T15:25:56.931335+00:00 heroku[web.1]: Starting process with command `/docker-entrypoint.sh`
2022-05-18T15:25:58.435759+00:00 app[web.1]: /docker-entrypoint.sh: line 1: 404:: not found
```

## Modification

Update the suexec url and updated curl command to fail on http errors.

## Result

The container will work again, and if the file moves again the build will fail.

## Testing

```shell
docker build -t adaptrislabs/interlok-hello-world:latest .
docker run -d --rm -p 8081:8081 -e PORT=8081 adaptrislabs/interlok-hello-world:latest
curl -s http://localhost:8081/
```
